### PR TITLE
Change Makefile to fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DEBUGFLAGS = -g
 all: $(TARGET)
  
 $(TARGET): $(OBJECTS) $(HEADERS)
-	$(CC) $(CFLAGS) $(DEBUGFLAGS) $(LDLIBS) -o $(TARGET) $(OBJECTS)
+	$(CC) $(CFLAGS) $(DEBUGFLAGS) -o $(TARGET) $(OBJECTS) $(LDLIBS)
  
 clean:
 	-rm -f $(OBJECTS)


### PR DESCRIPTION
The LDLIBS parameter has to be at the end, otherwise a current GCC will fail to build this.